### PR TITLE
fixes and improvements

### DIFF
--- a/util/FileMapping.h
+++ b/util/FileMapping.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #ifdef _WIN32


### PR DESCRIPTION
- select used ANARI backend at runtime via environment var ANARI_LIBRARY
- remove unused instances
- release local temporary objects
- compile fix: uint8_t needs \<cstdint\>